### PR TITLE
Исправлена ошибка WebSocket 1001 при переходе к игре

### DIFF
--- a/Hangman/Views/MultiplayerMenuView.swift
+++ b/Hangman/Views/MultiplayerMenuView.swift
@@ -50,9 +50,6 @@ struct MultiplayerMenuView: View {
 
             Spacer()
         }
-        .onDisappear {
-            WebSocketManager.shared.disconnect()
-        }
         .navigationTitle("Назад")
         .toolbar(.hidden, for: .navigationBar)
     }


### PR DESCRIPTION
Удален модификатор .onDisappear из MultiplayerMenuView, который вызывал преждевременное закрытие WebSocket-соединения при навигации на игровой экран. Это приводило к ошибке 1001 (Going Away).

Теперь соединение не будет автоматически разрываться, что решает проблему с ошибкой и восстанавливает функциональность мультиплеера.