### PR TITLE
Исправлена отправка запроса на новую игру в соревновательном режиме

### DIFF
--- a/Hangman/Services/WebSocketManager.swift
+++ b/Hangman/Services/WebSocketManager.swift
@@ -24,19 +24,16 @@ final class WebSocketManager: NSObject, URLSessionWebSocketDelegate {
     }
     
     func connect(mode: MultiplayerMode, language: String) {
+        self.mode = mode
+        self.lang = language
+
         if isConnected {
-            print("ℹ️ WebSocket уже подключен.")
-            if self.mode != mode || self.lang != language {
-                self.mode = mode
-                self.lang = language
-                sendFindOrCreate()
-            }
+            print("ℹ️ WebSocket уже подключен, отправляем новый запрос на поиск игры.")
+            sendFindOrCreate()
             return
         }
 
-        self.mode = mode
-        self.lang = language
-        
+        print("🔌 WebSocket подключается...")
         guard let url = URL(string: "wss://hangman.megoru.ru/ws") else {
             delegate?.didReceiveError("Неверный URL WebSocket")
             return


### PR DESCRIPTION
Изменена логика метода `connect` в `WebSocketManager`. Теперь, если метод вызывается при уже установленном соединении, он принудительно отправляет запрос на поиск новой игры (`sendFindOrCreate`).

Это исправляет баг, при котором кнопка 'Новая игра' в режиме '1 vs 1' не работала, так как предыдущая реализация блокировала отправку запроса, если режим игры не менялся.